### PR TITLE
Rclone portable include legal folder in nupkg

### DIFF
--- a/automatic/rclone.portable/rclone.portable.nuspec
+++ b/automatic/rclone.portable/rclone.portable.nuspec
@@ -22,5 +22,6 @@
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
   </files>
 </package>


### PR DESCRIPTION
Whoops, forgot to check that the legal folder was actually included in the nupkg.
I assumed that it was since it already existed.

Should fix the validator failure.